### PR TITLE
feat: support arrayUnion/Remove single values and arrays

### DIFF
--- a/src/utils/mutate.js
+++ b/src/utils/mutate.js
@@ -58,11 +58,15 @@ const primaryValue = (arr) =>
 
 const arrayUnion = (firebase, key, val) => {
   if (key !== '::arrayUnion') return null;
-  return firebase.firestore.FieldValue.arrayUnion(val);
+  const arr = Array.isArray(val) ? val : [val];
+  return firebase.firestore.FieldValue.arrayUnion(...arr);
 };
 
-const arrayRemove = (firebase, key, val) =>
-  key === '::arrayRemove' && firebase.firestore.FieldValue.arrayRemove(val);
+const arrayRemove = (firebase, key, val) => {
+  if (key !== '::arrayRemove') return null;
+  const arr = Array.isArray(val) ? val : [val];
+  return firebase.firestore.FieldValue.arrayRemove(...arr);
+};
 
 const increment = (firebase, key, val) =>
   key === '::increment' &&

--- a/src/utils/mutate.js
+++ b/src/utils/mutate.js
@@ -56,16 +56,14 @@ const primaryValue = (arr) =>
     ? null
     : arr;
 
-const arrayUnion = (firebase, key, val) => {
+const arrayUnion = (firebase, key, ...val) => {
   if (key !== '::arrayUnion') return null;
-  const arr = Array.isArray(val) ? val : [val];
-  return firebase.firestore.FieldValue.arrayUnion(...arr);
+  return firebase.firestore.FieldValue.arrayUnion(...val);
 };
 
-const arrayRemove = (firebase, key, val) => {
+const arrayRemove = (firebase, key, ...val) => {
   if (key !== '::arrayRemove') return null;
-  const arr = Array.isArray(val) ? val : [val];
-  return firebase.firestore.FieldValue.arrayRemove(...arr);
+  return firebase.firestore.FieldValue.arrayRemove(...val);
 };
 
 const increment = (firebase, key, val) =>

--- a/test/unit/utils/mutate.spec.js
+++ b/test/unit/utils/mutate.spec.js
@@ -300,9 +300,10 @@ describe('firestore.mutate()', () => {
         data: {
           name: 'Bravo Team 🎄',
           'deeply.nested.map': 'value',
-          'deeply.nested.array': ['::arrayUnion', 'add'],
+          'deeply.nested.array': ['::arrayUnion', ['first', 'second']],
           addArray: ['::arrayUnion', 'val'],
-          removeArray: ['::arrayRemove', 'item'],
+          removeItem: ['::arrayRemove', 'item'],
+          removeArray: ['::arrayRemove', ['item1', 'item2']],
           updateAt: ['::serverTimestamp'],
           counter: ['::increment', 3],
           null: null,
@@ -316,7 +317,7 @@ describe('firestore.mutate()', () => {
     expect(set.notCalled);
     expect(firestore.FieldValue.serverTimestamp).to.have.been.calledOnce;
     expect(firestore.FieldValue.increment).to.have.been.calledOnce;
-    expect(firestore.FieldValue.arrayRemove).to.have.been.calledOnce;
+    expect(firestore.FieldValue.arrayRemove).to.have.been.calledTwice;
     expect(firestore.FieldValue.arrayUnion).to.have.been.calledTwice;
   });
 });


### PR DESCRIPTION
### Description
Supported multiple values for arrayUnion/Remove in the mutate call.

mutate({id: '1', path: 'some/path', collaborators: ["::arrayUnion":['uid1', 'uid2']]})

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
