### PR TITLE
feat: optimistic reads

### DIFF
--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -1,4 +1,5 @@
 import produce, { createDraft, finishDraft } from 'immer';
+import debug from 'debug';
 import {
   set,
   unset,
@@ -22,6 +23,8 @@ import {
 import { actionTypes } from '../constants';
 import { getBaseQueryName } from '../utils/query';
 import mark from '../utils/profiling';
+
+const info = debug('rrf:cache');
 
 /**
  * @typedef {object & Object.<string, RRFQuery>} CacheState
@@ -360,6 +363,16 @@ function reprocessQuerires(draft, path) {
     set(draft, [key, 'ordered'], ordered);
   });
 
+  if (info.enabled) {
+    /* istanbul ignore next */
+    const overrides = JSON.parse(JSON.stringify(draft.databaseOverrides || {}));
+    /* istanbul ignore next */
+    info(
+      `reprocess ${path} (${queries.length} queries) with overrides`,
+      overrides,
+    );
+  }
+
   done();
 }
 
@@ -645,6 +658,8 @@ const failure = (state, { action, key, path }) =>
         (results, { writes }) => [
           ...results,
           ...writes.map(({ collection, path: _path, doc, id }) => {
+            info('remove override', `${collection}/${doc}`);
+
             // don't send data to ensure document override is deleted
             cleanOverride(draft, { path: _path || collection, id: id || doc });
 
@@ -740,6 +755,7 @@ const mutation = (state, { action, key, path }) =>
         translateMutationToOverrides(action, draft.database) || [];
 
       optimisiticUpdates.forEach(({ collection, doc, data }) => {
+        info('overriding', `${collection}/${doc}`, data);
         setWith(draft, ['databaseOverrides', collection, doc], data, Object);
       });
 

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -2,6 +2,7 @@ import { get } from 'lodash';
 import { setWith } from 'lodash/fp';
 import { actionTypes } from '../constants';
 import { pathFromMeta, preserveValuesFromState } from '../utils/reducers';
+import debug from 'debug';
 
 const {
   CLEAR_DATA,
@@ -14,6 +15,7 @@ const {
   DOCUMENT_REMOVED,
 } = actionTypes;
 
+const info = debug('rrf:data');
 /**
  * Reducer for data state.
  * @param {object} [state={}] - Current data redux state
@@ -60,6 +62,7 @@ export default function dataReducer(state = {}, action) {
         );
       }
       const alias = meta.storeAs ? [meta.storeAs] : pathFromMeta(meta);
+      info('LISTENER_RESPONSE', alias, data);
       // Set data to state (with merge) immutabily (lodash/fp's setWith creates copy)
       return setWith(Object, alias, data, state);
 
@@ -86,13 +89,16 @@ export default function dataReducer(state = {}, action) {
     case CLEAR_DATA:
       // support keeping data when logging out - #125 of react-redux-firebase
       if (action.preserve && action.preserve.data) {
+        info('log out and preserve', action.preserve.data);
         return preserveValuesFromState(state, action.preserve.data, {});
       }
       return {};
     case LISTENER_ERROR:
+      info('listener error');
       // Set data to state immutabily (lodash/fp's setWith creates copy)
       const nextState = setWith(Object, pathFromMeta(action.meta), null, state);
       if (action.preserve && action.preserve.data) {
+        info('error and preserve', action.preserve.data);
         return preserveValuesFromState(state, action.preserve.data, nextState);
       }
       const existingState = get(state, pathFromMeta(action.meta));

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -7,6 +7,7 @@ import {
   preserveValuesFromState,
   pathToArr,
 } from '../utils/reducers';
+import debug from 'debug';
 
 const {
   DOCUMENT_ADDED,
@@ -17,6 +18,8 @@ const {
   DOCUMENT_REMOVED,
   DOCUMENT_MODIFIED,
 } = actionTypes;
+
+const info = debug('rrf:ordered');
 
 /**
  * Create a new copy of an array with the provided item in a new array index
@@ -57,6 +60,7 @@ function newArrayWithItemMoved(collectionState, meta, ordered, newValue) {
 function modifyDoc(collectionState, action) {
   // Support moving a doc within an array
   if (action.payload.ordered) {
+    info('DOCUMENT_MODIFIED new order:', action.payload.ordered);
     const { newIndex, oldIndex } = action.payload.ordered;
     // newIndex/oldIndex values exist, item isn't being removed or added, and the index has changed
     if (

--- a/src/utils/mutate.js
+++ b/src/utils/mutate.js
@@ -1,6 +1,9 @@
 import { chunk, cloneDeep, flatten, mapValues } from 'lodash';
+import debug from 'debug';
 import { firestoreRef } from './query';
 import mark from './profiling';
+
+const info = debug('rrf:mutate');
 
 /**
  * @param {object} firestore
@@ -126,6 +129,7 @@ function write(firebase, operation = {}, writer = null) {
 
   if (writer) {
     const writeType = writer.commit ? 'Batching' : 'Transaction.set';
+    info(writeType, { id: ref.id, path: ref.parent.path, ...changes });
     if (requiresUpdate) {
       writer.update(ref, changes);
     } else {
@@ -133,6 +137,7 @@ function write(firebase, operation = {}, writer = null) {
     }
     return { id: ref.id, path: ref.parent.path, ...changes };
   }
+  info('Writing', { id: ref.id, path: ref.parent.path, ...changes });
   if (requiresUpdate) {
     return ref.update(changes);
   }
@@ -188,6 +193,7 @@ async function writeInTransaction(firebase, operations) {
         ? null
         : { ...doc.data(), id: doc.ref.id, path: doc.ref.parent.path };
     const getter = (ref) => {
+      info('Transaction.get ', { id: ref.id, path: ref.parent.path });
       return transaction.get(ref);
     };
 

--- a/test/unit/reducers/cacheReducer.spec.js
+++ b/test/unit/reducers/cacheReducer.spec.js
@@ -855,7 +855,7 @@ describe('cacheReducer', () => {
   });
 
   describe('UNSET_LISTENER', () => {
-    it('handles unset listener', () => {
+    it('unset removes query but maintains in database cache', () => {
       const doc1 = { key1: 'value1', id: 'testDocId1' }; // initial doc
 
       // Initial seed
@@ -887,7 +887,7 @@ describe('cacheReducer', () => {
       const pass2 = reducer(pass1, action2);
 
       expect(pass2.cache.testStoreAs).to.eql(undefined);
-      expect(pass2.cache.database[collection]).to.eql({});
+      expect(pass2.cache.database[collection]).to.eql({ [doc1.id]: doc1 });
     });
 
     it('handles a null payload.data', () => {


### PR DESCRIPTION
### Description
The end result is that calling useFirestoreConnect will synchronously read from the normalized cache and set results before adding listeners and sending the request to Firestore. 

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
Here's the end result of optimistic reads:
![ezgif-2-aea19c18801c](https://user-images.githubusercontent.com/140163/118901950-5d688400-b8c9-11eb-83dd-7a0ad03e8352.gif)

When SET_LISTENER is called it will use the query to find all relevant data in the normalized cache and set it on the `cache[storeAs].docs` & `cache[storeAs].ordered`. When Firestore listener returns data it updates the `cache.database` and updates `cache[storeAs].docs` & `cache[storeAs].ordered` with the new data.
