### PR TITLE
feat: optimistic reads

### DIFF
--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -105,7 +105,7 @@ const PROCESSES = {
   '>=': (a, b) => a >= b,
   '>': (a, b) => a > b,
   'array-contains': (a, b) => a.includes(b),
-  in: (a, b) => a.includes(b),
+  in: (a, b) => a && a.includes(b),
   'array-contains-any': (a, b) => b.some((b1) => a.includes(b1)),
   'not-in': (a, b) => !b.includes(a),
   '*': () => true,

--- a/test/unit/reducers/cacheReducer.spec.js
+++ b/test/unit/reducers/cacheReducer.spec.js
@@ -855,7 +855,7 @@ describe('cacheReducer', () => {
   });
 
   describe('UNSET_LISTENER', () => {
-    it('handles unset listener', () => {
+    it('unset removes query but maintains in database cache', () => {
       const doc1 = { key1: 'value1', id: 'testDocId1' }; // initial doc
 
       // Initial seed
@@ -887,7 +887,7 @@ describe('cacheReducer', () => {
       const pass2 = reducer(pass1, action2);
 
       expect(pass2.cache.testStoreAs).to.eql(undefined);
-      expect(pass2.cache.database[collection]).to.eql({});
+      expect(pass2.cache.database[collection]).to.eql({ [doc1.id]: doc1 });
     });
 
     it('handles a null payload.data', () => {


### PR DESCRIPTION
### Description
The end result is that calling useFirestoreConnect will synchronously read from the normalized cache and set results before adding listeners and sending the request to Firestore. 

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
Here's the end result of optimistic reads:
![ezgif-2-aea19c18801c](https://user-images.githubusercontent.com/140163/118901950-5d688400-b8c9-11eb-83dd-7a0ad03e8352.gif)

When SET_LISTENER is called it will use the query to find all relevant data in the normalized cache and set it on the `cache[storeAs].docs` & `cache[storeAs].ordered`. When Firestore listener returns data it updates the `cache.database` and updates `cache[storeAs].docs` & `cache[storeAs].ordered` with the new data.
