### PR TITLE
feat: returns undefined on initial read when in-memory db is empty

### DIFF
--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -98,9 +98,9 @@ export function get(firebase, dispatch, queryOption) {
           data: dataByIdSnapshot(snap),
           ordered: orderedFromSnap(snap),
           fromCache:
-            (typeof snap.metadata?.fromCache === 'boolean' &&
-              snap.metadata.fromCache) ||
-            true,
+            typeof snap.metadata?.fromCache === 'boolean'
+              ? snap.metadata.fromCache
+              : true,
         }),
         merge: {
           docs: mergeOrdered && mergeOrderedDocUpdates,

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -97,6 +97,7 @@ export function get(firebase, dispatch, queryOption) {
         payload: (snap) => ({
           data: dataByIdSnapshot(snap),
           ordered: orderedFromSnap(snap),
+          fromCache: (snap.metadata && snap.metadata.fromCache) || true,
         }),
         merge: {
           docs: mergeOrdered && mergeOrderedDocUpdates,

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -98,7 +98,8 @@ export function get(firebase, dispatch, queryOption) {
           data: dataByIdSnapshot(snap),
           ordered: orderedFromSnap(snap),
           fromCache:
-            (snap.metadata && typeof snap.metadata.fromCache === 'boolean') ||
+            (typeof snap.metadata?.fromCache === 'boolean' &&
+              snap.metadata.fromCache) ||
             true,
         }),
         merge: {

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -97,7 +97,9 @@ export function get(firebase, dispatch, queryOption) {
         payload: (snap) => ({
           data: dataByIdSnapshot(snap),
           ordered: orderedFromSnap(snap),
-          fromCache: (snap.metadata && snap.metadata.fromCache) || true,
+          fromCache:
+            (snap.metadata && typeof snap.metadata.fromCache === 'boolean') ||
+            true,
         }),
         merge: {
           docs: mergeOrdered && mergeOrderedDocUpdates,

--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -369,11 +369,8 @@ function reprocessQuerires(draft, path) {
 
     const docs = selectDocuments(draft, draft[key]);
     const ordered = docs.map(({ id, path: _path }) => [_path, id]);
-    set(
-      draft,
-      [key, 'docs'],
-      draft[key].via === 'memory' && docs.length === 0 ? undefined : docs,
-    );
+    const isInitialLoad = draft[key].via === 'memory' && docs.length === 0;
+    set(draft, [key, 'docs'], isInitialLoad ? undefined : docs);
     set(draft, [key, 'ordered'], ordered);
   });
 

--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -105,7 +105,7 @@ const PROCESSES = {
   '>=': (a, b) => a >= b,
   '>': (a, b) => a > b,
   'array-contains': (a, b) => a.includes(b),
-  in: (a, b) => a && a.includes(b),
+  in: (a, b) => a && b && b.includes(a),
   'array-contains-any': (a, b) => b.some((b1) => a.includes(b1)),
   'not-in': (a, b) => !b.includes(a),
   '*': () => true,

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -792,7 +792,8 @@ export function dispatchListenerResponse({
     mergeOrderedCollectionUpdates,
   } = firebase._.config || {};
   const fromCache =
-    (docData.metadata && typeof docData.metadata.fromCache === 'boolean') ||
+    (typeof docData.metadata?.fromCache === 'boolean' &&
+      docData.metadata.fromCache) ||
     true;
   const docChanges =
     typeof docData.docChanges === 'function'

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -791,6 +791,7 @@ export function dispatchListenerResponse({
     mergeOrderedDocUpdates,
     mergeOrderedCollectionUpdates,
   } = firebase._.config || {};
+  const fromCache = (docData.metadata && docData.metadata.fromCache) || true;
   const docChanges =
     typeof docData.docChanges === 'function'
       ? docData.docChanges()
@@ -810,6 +811,7 @@ export function dispatchListenerResponse({
       payload: {
         data: dataByIdSnapshot(docData),
         ordered: orderedFromSnap(docData),
+        fromCache,
       },
       merge: {
         docs: mergeOrdered && mergeOrderedDocUpdates,

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -791,7 +791,9 @@ export function dispatchListenerResponse({
     mergeOrderedDocUpdates,
     mergeOrderedCollectionUpdates,
   } = firebase._.config || {};
-  const fromCache = (docData.metadata && docData.metadata.fromCache) || true;
+  const fromCache =
+    (docData.metadata && typeof docData.metadata.fromCache === 'boolean') ||
+    true;
   const docChanges =
     typeof docData.docChanges === 'function'
       ? docData.docChanges()

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -792,9 +792,9 @@ export function dispatchListenerResponse({
     mergeOrderedCollectionUpdates,
   } = firebase._.config || {};
   const fromCache =
-    (typeof docData.metadata?.fromCache === 'boolean' &&
-      docData.metadata.fromCache) ||
-    true;
+    typeof docData.metadata?.fromCache === 'boolean'
+      ? docData.metadata.fromCache
+      : true;
   const docChanges =
     typeof docData.docChanges === 'function'
       ? docData.docChanges()

--- a/test/unit/actions/firestore.spec.js
+++ b/test/unit/actions/firestore.spec.js
@@ -463,7 +463,7 @@ describe('firestoreActions', () => {
             };
             const expectedAction2 = {
               meta: listenerConfig,
-              payload: { data: null, ordered: [] },
+              payload: { data: null, ordered: [], fromCache: true },
               merge: { collections: true, docs: true },
               type: actionTypes.LISTENER_RESPONSE,
             };
@@ -644,7 +644,7 @@ describe('firestoreActions', () => {
             };
             const expectedAction2 = {
               meta: listenerConfig,
-              payload: { data: null, ordered: [] },
+              payload: { data: null, ordered: [], fromCache: true },
               merge: { collections: true, docs: true },
               type: actionTypes.LISTENER_RESPONSE,
             };

--- a/test/unit/reducers/cacheReducer.spec.js
+++ b/test/unit/reducers/cacheReducer.spec.js
@@ -12,6 +12,68 @@ const initialState = {
 };
 
 describe('cacheReducer', () => {
+  describe('optimistic reads', () => {
+    it('SET_LISTENER returns undefined if nothing in memory', () => {
+      // Request to set listener
+      const action1 = {
+        meta: {
+          collection,
+          storeAs: 'testStoreAs',
+          where: [['key1', '==', 'value1']],
+          orderBy: ['key1'],
+          fields: ['id', 'other'],
+        },
+        payload: { name: 'testStoreAs' },
+        type: actionTypes.SET_LISTENER,
+      };
+
+      const pass1 = reducer(initialState, action1);
+
+      expect(pass1.cache.testStoreAs.docs).to.eql(undefined);
+    });
+
+    it('SET_LISTENER returns data if in memory', () => {
+      const doc1 = { key1: 'value1', other: 'test', id: 'testDocId1', path };
+
+      // Initial seed
+      const action1 = {
+        meta: {
+          collection,
+          storeAs: 'testStoreAs',
+          where: [['key1', '==', 'value1']],
+          orderBy: ['key1'],
+          fields: ['id', 'other'],
+        },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
+        type: actionTypes.LISTENER_RESPONSE,
+      };
+
+      const action2 = {
+        meta: {
+          collection,
+          storeAs: 'testStoreAs2',
+          where: [['other', '==', 'test']],
+          orderBy: ['key1'],
+          fields: ['id', 'other'],
+        },
+        payload: { name: 'testStoreAs2' },
+        type: actionTypes.SET_LISTENER,
+      };
+
+      const pass1 = reducer(initialState, action1);
+      const pass2 = reducer(pass1, action2);
+
+      expect(pass2.cache.testStoreAs2.docs[0]).to.eql({
+        other: 'test',
+        id: 'testDocId1',
+      });
+    });
+  });
+
   describe('query fields', () => {
     it('query fields return partial document', () => {
       const doc1 = { key1: 'value1', other: 'test', id: 'testDocId1', path };
@@ -25,7 +87,11 @@ describe('cacheReducer', () => {
           orderBy: ['value1'],
           fields: ['id', 'other'],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -48,7 +114,11 @@ describe('cacheReducer', () => {
           where: [['key1', '!=', 'value2']],
           orderBy: ['key1'],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -78,7 +148,11 @@ describe('cacheReducer', () => {
           fields: ['id', 'key1', 'anotherDocument'],
           populates: [['anotherId', anotherPath, 'anotherDocument']],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -87,7 +161,11 @@ describe('cacheReducer', () => {
           collection: another,
           storeAs: 'anotherStoreAs',
         },
-        payload: { data: { [doc2.id]: doc2 }, ordered: [doc2] },
+        payload: {
+          data: { [doc2.id]: doc2 },
+          ordered: [doc2],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -126,7 +204,11 @@ describe('cacheReducer', () => {
           fields: ['id', 'key1', 'others'],
           populates: [['anotherIds', anotherPath, 'others']],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -138,6 +220,7 @@ describe('cacheReducer', () => {
         payload: {
           data: { [doc2.id]: doc2, [doc3.id]: doc3 },
           ordered: [doc2, doc3],
+          fromCache: true,
         },
         type: actionTypes.LISTENER_RESPONSE,
       };
@@ -178,7 +261,11 @@ describe('cacheReducer', () => {
           fields: ['id', 'key1', 'others'],
           populates: [['sub.anotherIds', anotherPath, 'others']],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -190,6 +277,7 @@ describe('cacheReducer', () => {
         payload: {
           data: { [doc2.id]: doc2, [doc3.id]: doc3 },
           ordered: [doc2, doc3],
+          fromCache: true,
         },
         type: actionTypes.LISTENER_RESPONSE,
       };
@@ -223,7 +311,11 @@ describe('cacheReducer', () => {
           where: [['key1', '==', 'value1']],
           orderBy: ['value1'],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action2 = {
@@ -253,7 +345,11 @@ describe('cacheReducer', () => {
           storeAs: 'testStoreAs',
           where: [['key1', '==', 'value1']],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action2 = {
@@ -288,7 +384,11 @@ describe('cacheReducer', () => {
           storeAs: 'testStoreAs',
           where: [['key1', '==', 'value1']],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -330,7 +430,11 @@ describe('cacheReducer', () => {
           storeAs: 'testOne',
           where: [['key1', 'in', ['value1']]],
         },
-        payload: { data: { [first.id]: first }, ordered: [first] },
+        payload: {
+          data: { [first.id]: first },
+          ordered: [first],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action2 = {
@@ -339,7 +443,7 @@ describe('cacheReducer', () => {
           storeAs: 'testTwo',
           where: [['key1', '==', 'value2']],
         },
-        payload: { data: {}, ordered: [] },
+        payload: { data: {}, ordered: [], fromCache: true },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action3 = {
@@ -364,7 +468,7 @@ describe('cacheReducer', () => {
     });
   });
 
-  describe('optimistic updates', () => {
+  describe('optimistic writes', () => {
     it('less than or equal', () => {
       const first = { key1: 1, id: 'testDocId1', path };
       const second = { key1: 2, id: 'testDocId1', path };
@@ -376,7 +480,11 @@ describe('cacheReducer', () => {
           storeAs: 'testOne',
           where: [['key1', '<=', 1]],
         },
-        payload: { data: { [first.id]: first }, ordered: [first] },
+        payload: {
+          data: { [first.id]: first },
+          ordered: [first],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action2 = {
@@ -385,7 +493,7 @@ describe('cacheReducer', () => {
           storeAs: 'testTwo',
           where: [['key1', '>=', 2]],
         },
-        payload: { data: {}, ordered: [] },
+        payload: { data: {}, ordered: [], fromCache: true },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action3 = {
@@ -420,7 +528,11 @@ describe('cacheReducer', () => {
           storeAs: 'testOne',
           where: [['key1', '<', 2]],
         },
-        payload: { data: { [first.id]: first }, ordered: [first] },
+        payload: {
+          data: { [first.id]: first },
+          ordered: [first],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action2 = {
@@ -429,7 +541,7 @@ describe('cacheReducer', () => {
           storeAs: 'testTwo',
           where: [['key1', '>', 1]],
         },
-        payload: { data: {}, ordered: [] },
+        payload: { data: {}, ordered: [], fromCache: true },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action3 = {
@@ -464,7 +576,11 @@ describe('cacheReducer', () => {
           storeAs: 'testOne',
           where: [['key1', '!=', 2]],
         },
-        payload: { data: { [first.id]: first }, ordered: [first] },
+        payload: {
+          data: { [first.id]: first },
+          ordered: [first],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action2 = {
@@ -473,7 +589,7 @@ describe('cacheReducer', () => {
           storeAs: 'testTwo',
           where: [['key1', '>', 1]],
         },
-        payload: { data: {}, ordered: [] },
+        payload: { data: {}, ordered: [], fromCache: true },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action3 = {
@@ -508,7 +624,11 @@ describe('cacheReducer', () => {
           storeAs: 'notTwo',
           where: [['key1', 'not-in', [2]]],
         },
-        payload: { data: { [first.id]: first }, ordered: [first] },
+        payload: {
+          data: { [first.id]: first },
+          ordered: [first],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action2 = {
@@ -517,7 +637,11 @@ describe('cacheReducer', () => {
           storeAs: 'isIdMatch',
           where: [['__name__', '==', 'testDocId1']],
         },
-        payload: { data: { [first.id]: first }, ordered: [first] },
+        payload: {
+          data: { [first.id]: first },
+          ordered: [first],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action3 = {
@@ -549,7 +673,11 @@ describe('cacheReducer', () => {
           storeAs: 'testOne',
           where: [['key1.val', 'array-contains', 1]],
         },
-        payload: { data: { [first.id]: first }, ordered: [first] },
+        payload: {
+          data: { [first.id]: first },
+          ordered: [first],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action2 = {
@@ -558,7 +686,7 @@ describe('cacheReducer', () => {
           storeAs: 'testTwo',
           where: [['key1.val', 'array-contains-any', [2]]],
         },
-        payload: { data: {}, ordered: [] },
+        payload: { data: {}, ordered: [], fromCache: true },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const action3 = {
@@ -582,6 +710,7 @@ describe('cacheReducer', () => {
       expect(pass3.cache.testTwo.docs[0]).to.eql(second);
     });
   });
+
   describe('DOCUMENT_ADDED', () => {
     it('Firestore adds new document without overrides', () => {
       const doc1 = { key1: 'value1', id: 'testDocId1', path };
@@ -594,7 +723,11 @@ describe('cacheReducer', () => {
           where: [['key1', '==', 'value1']],
           orderBy: ['key1'],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -633,7 +766,11 @@ describe('cacheReducer', () => {
           where: [['key1', '==', 'value1']],
           orderBy: ['key1'],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -700,7 +837,11 @@ describe('cacheReducer', () => {
           where: [['key1', '==', 'value1']],
           orderBy: ['key1'],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -776,6 +917,7 @@ describe('cacheReducer', () => {
         payload: {
           data: { [doc1.id]: doc1, [doc2.id]: doc2 },
           ordered: [doc2, doc1],
+          fromCache: true,
         },
         type: actionTypes.LISTENER_RESPONSE,
       };
@@ -792,6 +934,7 @@ describe('cacheReducer', () => {
         payload: {
           data: { key2: 2, id: 'testDocId2', path },
           ordered: { newIndex: -1, oldIndex: 0 },
+          fromCache: true,
         },
       };
 
@@ -822,6 +965,7 @@ describe('cacheReducer', () => {
         payload: {
           data: { [doc1.id]: doc1, [doc2.id]: doc2 },
           ordered: [doc2, doc1],
+          fromCache: true,
         },
         type: actionTypes.LISTENER_RESPONSE,
       };
@@ -866,7 +1010,11 @@ describe('cacheReducer', () => {
           where: [['key1', '==', 'value1']],
           orderBy: ['value1'],
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 
@@ -897,7 +1045,7 @@ describe('cacheReducer', () => {
           storeAs: 'testStoreAs',
           where: ['abc', '===', 123],
         },
-        payload: { data: null, ordered: [] },
+        payload: { data: null, ordered: [], fromCache: true },
         type: actionTypes.LISTENER_RESPONSE,
       };
       const pass1 = reducer(initialState, action1);
@@ -947,7 +1095,11 @@ describe('cacheReducer', () => {
           where: ['key1', '==', 'value1'],
           storeAs: 'testStoreAs',
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       // mutate
@@ -1000,7 +1152,11 @@ describe('cacheReducer', () => {
           where: ['key1', '==', 'value1'],
           storeAs: 'testStoreAs',
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       // mutate
@@ -1065,7 +1221,11 @@ describe('cacheReducer', () => {
           collection,
           storeAs: 'testStoreAs',
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       // mutate
@@ -1148,7 +1308,11 @@ describe('cacheReducer', () => {
           collection,
           storeAs: 'testStoreAs',
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       // mutate
@@ -1217,7 +1381,11 @@ describe('cacheReducer', () => {
           collection,
           storeAs: 'testStoreAs',
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
       // mutate
@@ -1285,7 +1453,11 @@ describe('cacheReducer', () => {
           where: ['key1', '==', 'value1'],
           storeAs: 'testStoreAs',
         },
-        payload: { data: { [doc1.id]: doc1 }, ordered: [doc1] },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
         type: actionTypes.LISTENER_RESPONSE,
       };
 


### PR DESCRIPTION
To test in Tara locally run:
```ts
cd <redux-firestore-fork-location>
rm -rf ../tara-js/node_modules/redux-firestore && ln -s $PWD ../tara-js/node_modules/redux-firestore
yarn watch
cd <tara-js-location>
DEBUG=rrf:* yarn start
```

### Description

**Case 1:** On the initial read (SET_LISTENER action) if there is _no results_ matching in the in-memory database,
  then it will set `docs` field to _undefined_.

**Case 2:** On the initial read (SET_LISTENER action) if there _1 or more_ results match from the in-memory database,
  then it will set `docs` field to _any matching documents_ in the in-memory database.

In both cases once Firestore returns any results it will update the in-memory database and the query results.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->

Test for case 1:
```ts
it('SET_LISTENER returns undefined if nothing in memory', () => {
      // Request to set listener
      const action1 = {
        meta: {
          collection,
          storeAs: 'testStoreAs',
          where: [['key1', '==', 'value1']],
          orderBy: ['key1'],
          fields: ['id', 'other'],
        },
        payload: { name: 'testStoreAs' },
        type: actionTypes.SET_LISTENER,
      };

      const pass1 = reducer(initialState, action1);

      expect(pass1.cache.testStoreAs.docs).to.eql(undefined);
    });
```

Test for case 2:
```ts
it('SET_LISTENER returns data if in memory', () => {
      const doc1 = { key1: 'value1', other: 'test', id: 'testDocId1', path };

      // Initial seed
      const action1 = {
        meta: {
          collection,
          storeAs: 'testStoreAs',
          where: [['key1', '==', 'value1']],
          orderBy: ['key1'],
          fields: ['id', 'other'],
        },
        payload: {
          data: { [doc1.id]: doc1 },
          ordered: [doc1],
          fromCache: true,
        },
        type: actionTypes.LISTENER_RESPONSE,
      };

      const action2 = {
        meta: {
          collection,
          storeAs: 'testStoreAs2',
          where: [['other', '==', 'test']],
          orderBy: ['key1'],
          fields: ['id', 'other'],
        },
        payload: { name: 'testStoreAs2' },
        type: actionTypes.SET_LISTENER,
      };

      const pass1 = reducer(initialState, action1);
      const pass2 = reducer(pass1, action2);

      expect(pass2.cache.testStoreAs2.docs[0]).to.eql({
        other: 'test',
        id: 'testDocId1',
      });
    });
```
