### PR TITLE
fix: corrected query limit

### DIFF
--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -283,7 +283,6 @@ const overridesTransducers = (overrides, collection) => {
 /**
  * @name buildTransducer
  * Convert the query to a transducer for the query results
- * partialRight(map, (spy) => { console.log(spy); return spy; })
  * @param {?CacheState.databaseOverrides} overrides -
  * @param {RRFQuery} query - query used to get data from firestore
  * @returns {Function} - Transducer will return a modifed array of documents

--- a/test/unit/reducers/cacheReducer.spec.js
+++ b/test/unit/reducers/cacheReducer.spec.js
@@ -70,6 +70,7 @@ describe('cacheReducer', () => {
       expect(pass2.cache.testStoreAs2.docs[0]).to.eql({
         other: 'test',
         id: 'testDocId1',
+        path,
       });
     });
   });
@@ -77,6 +78,9 @@ describe('cacheReducer', () => {
   describe('query fields', () => {
     it('query fields return partial document', () => {
       const doc1 = { key1: 'value1', other: 'test', id: 'testDocId1', path };
+      const doc2 = { key1: 'value1', other: 'limit', id: 'testDocId2', path };
+      const doc3 = { key1: 'value1', other: 'third', id: 'testDocId3', path };
+      const doc4 = { key1: 'value1', other: 'fourth', id: 'testDocId4', path };
 
       // Initial seed
       const action1 = {
@@ -84,23 +88,46 @@ describe('cacheReducer', () => {
           collection,
           storeAs: 'testStoreAs',
           where: [['key1', '==', 'value1']],
-          orderBy: ['value1'],
+          orderBy: ['key1'],
           fields: ['id', 'other'],
+          limit: 2,
         },
         payload: {
-          data: { [doc1.id]: doc1 },
-          ordered: [doc1],
+          data: { [doc1.id]: doc1, [doc2.id]: doc2, [doc3.id]: doc3 },
+          ordered: [doc1, doc2, doc3],
           fromCache: true,
         },
         type: actionTypes.LISTENER_RESPONSE,
       };
+      const action2 = {
+        type: actionTypes.OPTIMISTIC_ADDED,
+        meta: {
+          collection,
+          doc: doc4.id,
+        },
+        payload: { data: doc4 },
+      };
 
       const pass1 = reducer(initialState, action1);
+      const pass2 = reducer(pass1, action2);
 
       expect(pass1.cache.testStoreAs.docs[0]).to.eql({
         other: 'test',
         id: 'testDocId1',
+        path,
       });
+      expect(pass1.cache.testStoreAs.docs[1]).to.eql({
+        other: 'limit',
+        id: 'testDocId2',
+        path,
+      });
+      expect(pass2.cache.testStoreAs.docs[1]).to.eql({
+        other: 'limit',
+        id: 'testDocId2',
+        path,
+      });
+
+      expect(pass2.cache.testStoreAs.docs[2]).to.eql(undefined);
     });
 
     it('empty fields return entire document', () => {
@@ -175,11 +202,13 @@ describe('cacheReducer', () => {
       expect(pass1.cache.testStoreAs.docs[0]).to.eql({
         id: 'testDocId1',
         key1: 'value1',
+        path,
       });
       expect(pass2.cache.testStoreAs.docs[0]).to.eql({
         anotherDocument: doc2,
         key1: 'value1',
         id: 'testDocId1',
+        path,
       });
     });
 
@@ -231,12 +260,14 @@ describe('cacheReducer', () => {
       expect(pass1.cache.testStoreAs.docs[0]).to.eql({
         id: 'testDocId1',
         key1: 'value1',
+        path,
       });
 
       expect(pass2.cache.testStoreAs.docs[0]).to.eql({
         others: [doc3, doc2],
         key1: 'value1',
         id: 'testDocId1',
+        path,
       });
     });
 
@@ -288,12 +319,14 @@ describe('cacheReducer', () => {
       expect(pass1.cache.testStoreAs.docs[0]).to.eql({
         id: 'testDocId1',
         key1: 'value1',
+        path,
       });
 
       expect(pass2.cache.testStoreAs.docs[0]).to.eql({
         others: [doc3, doc2],
         key1: 'value1',
         id: 'testDocId1',
+        path,
       });
     });
   });


### PR DESCRIPTION
### Description

When a query reprocessed it wouldn't include the limit but all items in the normalized store. This change ensures limits are enforced. 


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
