### PR TITLE
perf: on multiple changes, batch reprocessing at the end

### DIFF
--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -655,7 +655,9 @@ const modify = (state, { action, key, path }) =>
     }
 
     // reprocessing unifies any order changes from firestore
-    reprocessQuerires(draft, path);
+    if (action.meta.reprocess !== false) {
+      reprocessQuerires(draft, path);
+    }
 
     done();
     return draft;

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -803,8 +803,9 @@ export function dispatchListenerResponse({
   if (docChanges && docChanges.length < docData.size) {
     // Loop to dispatch for each change if there are multiple
     // TODO: Option for dispatching multiple changes in single action
-    docChanges.forEach((change) => {
-      dispatch(docChangeEvent(change, meta));
+    docChanges.forEach((change, index) => {
+      const lastChange = index === docChanges.length - 1;
+      dispatch(docChangeEvent(change, { reprocess: lastChange, ...meta }));
     });
   } else {
     // Dispatch action for whole collection change


### PR DESCRIPTION
### Description

When changes sets come in from Firestore Redux only changes the discrete documents that have been modified. 

**Existing**: The existing code reprocesses all queries for the collection after each doc change.
**New**: Each change only updates the normalized store, the last change in the list will reprocess all queries for that collection. This avoids wasted reprocessing cycles. 

Using dev with Tara-ai workspace to cold boot the sprint page, before:
<img width="761" alt="reprocess-tara-before" src="https://user-images.githubusercontent.com/140163/121429611-f5d3b080-c92b-11eb-8b97-8ec68f6c321e.png">

Using dev with Tara-ai workspace to cold boot the sprint page, after:
<img width="756" alt="reprocess-tara-after" src="https://user-images.githubusercontent.com/140163/121429727-13a11580-c92c-11eb-9fd0-f0f8397e2c1d.png">


### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
