### PR TITLE
fix: `in` operator in query processes map

### DIFF
--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -105,7 +105,7 @@ const PROCESSES = {
   '>=': (a, b) => a >= b,
   '>': (a, b) => a > b,
   'array-contains': (a, b) => a.includes(b),
-  in: (a, b) => a && b && b.includes(a),
+  in: (a, b) => Array.isArray(b) && b.includes(a),
   'array-contains-any': (a, b) => b.some((b1) => a.includes(b1)),
   'not-in': (a, b) => !b.includes(a),
   '*': () => true,


### PR DESCRIPTION
### Description

`a && b && b.includes(a)` does not work if `a==0`, since that result in the whole expression being false (even if `0` is actually present in b), since `0` is falsy.

This fixes that problem and also adds check to see if b is an array to make sure that we can call `includes()` on it.


### Check List
If not relevant to pull request, check off as complete

- [ ] All tests passing
- [ ] Docs updated with any changes or examples if applicable
- [ ] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
