### PR TITLE
feat: Preserve data on UNSET_LISTENER

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,8 @@ module.exports = {
     'valid-jsdoc': 0, // from google
     'no-confusing-arrow': 0,
     'no-case-declarations': 0,
-    'arrow-parens': [2, 'as-needed'],
+    'no-param-reassign': [2, { props: false }],
+    'arrow-parens': 0, // handled by Prettier
     'prefer-default-export': 0,
     'jsdoc/newline-after-description': 0,
     'jsdoc/no-undefined-types': [1, { definedTypes: ['firebase'] }],

--- a/docs/query.md
+++ b/docs/query.md
@@ -390,6 +390,12 @@ Default: `null`
 
 Values to preserve from state when LISTENER_ERROR action is dispatched.
 
+#### preserveCacheAfterUnset
+
+Default: `true`
+
+Indicates whether to preserve or remove the cache data from the store after a listener is unset.
+
 #### onAttemptCollectionDelete
 
 Default: `null`

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,8 @@ export interface Config {
   // https://github.com/prescottprue/redux-firestore#preserveonlistenererror
   preserveOnListenerError: null | object;
 
+  preserveCacheAfterUnset: boolean;
+
   // https://github.com/prescottprue/redux-firestore#onattemptcollectiondelete
   onAttemptCollectionDelete:
     | null

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -16,7 +16,6 @@ import {
   snapshotCache,
 } from '../utils/query';
 
-const pathListenerCounts = {};
 /**
  * Add data to a collection or document on Cloud Firestore with the call to
  * the Firebase library being wrapped in action dispatches.
@@ -305,8 +304,8 @@ export function setListeners(firebase, dispatch, listeners) {
   if (config.oneListenerPerPath) {
     listeners.forEach((listener) => {
       const path = getQueryName(listener);
-      const oldListenerCount = pathListenerCounts[path] || 0;
-      pathListenerCounts[path] = oldListenerCount + 1;
+      const oldListenerCount = firebase._.pathListenerCounts[path] || 0;
+      firebase._.pathListenerCounts[path] = oldListenerCount + 1;
 
       // If we already have an attached listener exit here
       if (oldListenerCount > 0) {
@@ -320,13 +319,13 @@ export function setListeners(firebase, dispatch, listeners) {
 
     listeners.forEach((listener) => {
       const path = getQueryName(listener);
-      const oldListenerCount = pathListenerCounts[path] || 0;
+      const oldListenerCount = firebase._.pathListenerCounts[path] || 0;
       const multipleListenersEnabled =
         typeof allowMultipleListeners === 'function'
           ? allowMultipleListeners(listener, firebase._.listeners)
           : allowMultipleListeners;
 
-      pathListenerCounts[path] = oldListenerCount + 1;
+      firebase._.pathListenerCounts[path] = oldListenerCount + 1;
 
       // If we already have an attached listener exit here
       if (oldListenerCount === 0 || multipleListenersEnabled) {
@@ -369,16 +368,19 @@ export function unsetListeners(firebase, dispatch, listeners) {
   // Keep one listener path even when detaching
   listeners.forEach((listener) => {
     const path = getQueryName(listener);
-    const listenerExists = pathListenerCounts[path] >= 1;
+    const listenerExists = firebase._.pathListenerCounts[path] >= 1;
     const multipleListenersEnabled =
       typeof allowMultipleListeners === 'function'
         ? allowMultipleListeners(listener, firebase._.listeners)
         : allowMultipleListeners;
 
     if (listenerExists) {
-      pathListenerCounts[path] -= 1;
+      firebase._.pathListenerCounts[path] -= 1;
       // If we aren't supposed to have listners for this path, then remove them
-      if (pathListenerCounts[path] === 0 || multipleListenersEnabled) {
+      if (
+        firebase._.pathListenerCounts[path] === 0 ||
+        multipleListenersEnabled
+      ) {
         unsetListener(firebase, dispatch, listener);
       }
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -104,6 +104,8 @@ export const actionTypes = {
  * state.ordered if you have a listener attached.
  * @property {object} preserveOnListenerError - `null` Values to
  * preserve from state when LISTENER_ERROR action is dispatched.
+ * @property {boolean} preserveCacheAfterUnset - `true` Indicates whether to
+ * preserve or remove the cache data from the store after a listener is unset.
  * @property {boolean} enhancerNamespace - `'firestore'` Namespace under which
  * enhancer places internal instance on redux store (i.e. store.firestore).
  * @property {boolean|Function} allowMultipleListeners - `false` Whether or not
@@ -126,6 +128,7 @@ export const defaultConfig = {
   allowMultipleListeners: false,
   preserveOnDelete: null,
   preserveOnListenerError: null,
+  preserveCacheAfterUnset: true,
   onAttemptCollectionDelete: null,
   mergeOrdered: true,
   mergeOrderedDocUpdates: true,

--- a/src/createFirestoreInstance.js
+++ b/src/createFirestoreInstance.js
@@ -17,6 +17,8 @@ export default function createFirestoreInstance(firebase, configs, dispatch) {
   const defaultInternals = {
     // Setup empty listeners object (later used to track listeners)
     listeners: {},
+    // Setup empty path listeners count object (later used to track listeners)
+    pathListenerCounts: {},
     // Extend default config with provided config
     config: { ...defaultConfig, ...configs },
   };

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -46,7 +46,7 @@ let firestoreInstance;
  * const store = createStoreWithFirestore(rootReducer, initialState)
  */
 export default function reduxFirestore(firebaseInstance, otherConfig) {
-  return next => (reducer, initialState, middleware) => {
+  return (next) => (reducer, initialState, middleware) => {
     const store = next(reducer, initialState, middleware);
 
     const configs = { ...defaultConfig, ...otherConfig };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -47,7 +47,7 @@ const typesMap = {
  * @returns {Function} Middleware function
  */
 export default function reduxFirestoreMiddleware(firestore) {
-  return store => next => action => {
+  return (store) => (next) => (action) => {
     const callAPI = action.type === CALL_FIRESTORE ? action : undefined;
     if (typeof callAPI === 'undefined') return next(action);
 
@@ -64,7 +64,7 @@ export default function reduxFirestoreMiddleware(firestore) {
       throw new Error('Expected an array of three action types.');
     }
 
-    if (!types.every(type => typeof type === 'string')) {
+    if (!types.every((type) => typeof type === 'string')) {
       throw new Error('Expected action types to be strings.');
     }
 
@@ -83,8 +83,8 @@ export default function reduxFirestoreMiddleware(firestore) {
     next({ type: requestType });
     const callInfoObj = { method };
     return callFirestore(firestore, callInfoObj)
-      .then(response => next({ response, method, args, type: successType }))
-      .catch(error =>
+      .then((response) => next({ response, method, args, type: successType }))
+      .catch((error) =>
         next(
           actionWith({
             type: failureType,

--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -594,6 +594,22 @@ const initialize = (state, { action, key, path }) =>
     return draft;
   });
 
+const conclude = (state, { action, key, path }) =>
+  produce(state, (draft) => {
+    const done = mark(`cache.UNSET_LISTENER`, key);
+    if (draft[key]) {
+      if (!action.payload.preserveCache) {
+        // remove query
+        unset(draft, [key]);
+      }
+
+      reprocessQueries(draft, path);
+    }
+
+    done();
+    return draft;
+  });
+
 const modify = (state, { action, key, path }) =>
   produce(state, (draft) => {
     const done = mark(`cache.DOCUMENT_MODIFIED`, key);
@@ -772,6 +788,7 @@ const HANDLERS = {
   [actionTypes.SET_LISTENER]: initialize,
   [actionTypes.LISTENER_RESPONSE]: initialize,
   [actionTypes.GET_SUCCESS]: initialize,
+  [actionTypes.UNSET_LISTENER]: conclude,
   [actionTypes.DOCUMENT_ADDED]: modify,
   [actionTypes.DOCUMENT_MODIFIED]: modify,
   [actionTypes.DELETE_SUCCESS]: deletion,

--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -351,12 +351,12 @@ function selectDocuments(reducerState, query) {
 }
 
 /**
- * @name reprocessQuerires
+ * @name reprocessQueries
  * Rerun all queries that contain the same collection
  * @param {object} draft - reducer state
  * @param {string} path - path to rerun queries for
  */
-function reprocessQuerires(draft, path) {
+function reprocessQueries(draft, path) {
   const done = mark(`reprocess.${path}`);
   const queries = [];
 
@@ -588,7 +588,7 @@ const initialize = (state, { action, key, path }) =>
     });
 
     // append docs field to query
-    reprocessQuerires(draft, path);
+    reprocessQueries(draft, path);
 
     done();
     return draft;
@@ -636,7 +636,7 @@ const modify = (state, { action, key, path }) =>
 
     // reprocessing unifies any order changes from firestore
     if (action.meta.reprocess !== false) {
-      reprocessQuerires(draft, path);
+      reprocessQueries(draft, path);
     }
 
     done();
@@ -668,7 +668,7 @@ const failure = (state, { action, key, path }) =>
 
       const uniquePaths = Array.from(new Set(allPaths));
       if (uniquePaths.length > 0) {
-        reprocessQuerires(draft, uniquePaths);
+        reprocessQueries(draft, uniquePaths);
       }
     }
 
@@ -692,7 +692,7 @@ const deletion = (state, { action, key, path }) =>
     }
 
     // reprocess
-    reprocessQuerires(draft, path);
+    reprocessQueries(draft, path);
 
     done();
     return draft;
@@ -717,7 +717,7 @@ const remove = (state, { action, key, path }) =>
     }
 
     // reprocess
-    reprocessQuerires(draft, path);
+    reprocessQueries(draft, path);
 
     done();
     return draft;
@@ -732,7 +732,7 @@ const optimistic = (state, { action, key, path }) =>
       Object,
     );
 
-    reprocessQuerires(draft, path);
+    reprocessQueries(draft, path);
     return draft;
   });
 
@@ -740,7 +740,7 @@ const reset = (state, { action, key, path }) =>
   produce(state, (draft) => {
     cleanOverride(draft, { path, id: action.meta.doc });
 
-    reprocessQuerires(draft, path);
+    reprocessQueries(draft, path);
     return draft;
   });
 
@@ -760,7 +760,7 @@ const mutation = (state, { action, key, path }) =>
         ...new Set(optimisiticUpdates.map(({ collection }) => collection)),
       ];
       updatePaths.forEach((path) => {
-        reprocessQuerires(draft, path);
+        reprocessQueries(draft, path);
       });
     }
 

--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -594,30 +594,6 @@ const initialize = (state, { action, key, path }) =>
     return draft;
   });
 
-const conclude = (state, { action, key, path }) =>
-  produce(state, (draft) => {
-    const done = mark(`cache.UNSET_LISTENER`, key);
-    if (draft[key]) {
-      // all ids for the collection type, except query to be unset
-      const activeIds = Object.keys(draft).reduce((inUse, dbKey) => {
-        const { collection, ordered } = draft[dbKey];
-        if (dbKey !== key && collection === path) {
-          return [...inUse, ...ordered.map(([___, id]) => id)];
-        }
-
-        return inUse;
-      }, []);
-
-      // remove query
-      unset(draft, [key]);
-
-      reprocessQuerires(draft, path);
-    }
-
-    done();
-    return draft;
-  });
-
 const modify = (state, { action, key, path }) =>
   produce(state, (draft) => {
     const done = mark(`cache.DOCUMENT_MODIFIED`, key);
@@ -796,7 +772,6 @@ const HANDLERS = {
   [actionTypes.SET_LISTENER]: initialize,
   [actionTypes.LISTENER_RESPONSE]: initialize,
   [actionTypes.GET_SUCCESS]: initialize,
-  [actionTypes.UNSET_LISTENER]: conclude,
   [actionTypes.DOCUMENT_ADDED]: modify,
   [actionTypes.DOCUMENT_MODIFIED]: modify,
   [actionTypes.DELETE_SUCCESS]: deletion,

--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -66,14 +66,14 @@ const info = debug('rrf:cache');
  */
 
 /**
- * @typedef {Object} Mutation_v1
+ * @typedef {object} Mutation_v1
  * @property {string} collection - firestore path into the parent collection
  * @property {string} doc - firestore document id
- * @property {Object} data - document to be saved
+ * @property {object} data - document to be saved
  */
 
 /**
- * @typedef {Object} Mutation_v2
+ * @typedef {object} Mutation_v2
  * The full document to be saved in firestore with 2 additional properties
  * @property {string} path - firestore path into the parent collection
  * @property {string} id - firestore document id

--- a/src/reducers/crossSliceReducer.js
+++ b/src/reducers/crossSliceReducer.js
@@ -11,7 +11,7 @@ import { actionTypes } from '../constants';
  * @returns {object} Cross slice state
  */
 export default function crossSliceReducer(state = {}, action) {
-  return produce(state, draft => {
+  return produce(state, (draft) => {
     switch (action.type) {
       case actionTypes.DOCUMENT_MODIFIED:
       case actionTypes.DOCUMENT_ADDED:
@@ -21,12 +21,12 @@ export default function crossSliceReducer(state = {}, action) {
         // Take all of the query values and plop them into composite, replacing the existing data entirely
         const groups = groupBy(
           (!!state.queries && Object.values(state.queries)) || [],
-          c => c.storeAs || c.collection,
+          (c) => c.storeAs || c.collection,
         );
 
-        Object.keys(groups).forEach(storeAs => {
+        Object.keys(groups).forEach((storeAs) => {
           const updated = {};
-          groups[storeAs].forEach(item =>
+          groups[storeAs].forEach((item) =>
             merge(updated, get(item, 'data', {})),
           );
 

--- a/src/reducers/dataReducer.js
+++ b/src/reducers/dataReducer.js
@@ -1,8 +1,8 @@
 import { get } from 'lodash';
 import { setWith } from 'lodash/fp';
+import debug from 'debug';
 import { actionTypes } from '../constants';
 import { pathFromMeta, preserveValuesFromState } from '../utils/reducers';
-import debug from 'debug';
 
 const {
   CLEAR_DATA,

--- a/src/reducers/errorsReducer.js
+++ b/src/reducers/errorsReducer.js
@@ -24,7 +24,7 @@ function errorsAllIds(state = [], { meta, type }) {
     case CLEAR_ERRORS:
       return [];
     case CLEAR_ERROR:
-      return state.filter(lId => lId !== getQueryName(meta));
+      return state.filter((lId) => lId !== getQueryName(meta));
     default:
       return state;
   }

--- a/src/reducers/listenersReducer.js
+++ b/src/reducers/listenersReducer.js
@@ -8,7 +8,7 @@ import { combineReducers } from '../utils/reducers';
  * @param {object} [state={}] - Current listenersById redux state
  * @param {object} action - Object containing the action that was dispatched
  * @param {string} action.type - Type of action that was dispatched
- * @param {String} action.path - Path of action
+ * @param {string} action.path - Path of action
  * @param {object} action.payload - THe payload
  * @returns {object} listenersById state after reduction (used in listeners)
  * @private

--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -1,5 +1,6 @@
 import { size, get, unionBy, reject, omit, map, keyBy, isEqual } from 'lodash';
 import { merge as mergeObjects } from 'lodash/fp';
+import debug from 'debug';
 import { actionTypes } from '../constants';
 import {
   updateItemInArray,
@@ -7,7 +8,6 @@ import {
   preserveValuesFromState,
   pathToArr,
 } from '../utils/reducers';
-import debug from 'debug';
 
 const {
   DOCUMENT_ADDED,

--- a/src/reducers/queriesReducer.js
+++ b/src/reducers/queriesReducer.js
@@ -20,7 +20,7 @@ export function isComposable(action) {
  * @returns {object} Queries state
  */
 export default function queriesReducer(state = {}, action) {
-  return produce(state, draft => {
+  return produce(state, (draft) => {
     if (!isComposable(action)) {
       return state;
     }

--- a/src/utils/profiling.js
+++ b/src/utils/profiling.js
@@ -22,6 +22,7 @@ const perf = win && win.performance;
  *
  * @param {*} marker
  * @param {*} isDone
+ * @param context
  * @returns {Function}
  */
 export default function mark(marker, context = '') {

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -413,11 +413,12 @@ export function detachListener(firebase, dispatch, meta) {
     firebase._.listeners[name]();
     delete firebase._.listeners[name]; // eslint-disable-line no-param-reassign
   }
+  const { preserveCacheAfterUnset: preserveCache } = firebase._.config || {};
 
   dispatch({
     type: actionTypes.UNSET_LISTENER,
     meta,
-    payload: { name },
+    payload: { name, preserveCache },
   });
 }
 

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -7,7 +7,7 @@ import { isBoolean, pick, replace, trimStart, flatten } from 'lodash';
  * @private
  */
 export function pathToArr(path) {
-  return path ? path.split(/\//).filter(p => !!p) : [];
+  return path ? path.split(/\//).filter((p) => !!p) : [];
 }
 
 /**
@@ -114,7 +114,7 @@ export function pathFromMeta(meta) {
 export function updateItemInArray(array, itemId, updateItemCallback) {
   let matchFound = false;
   const modified = Array.isArray(array)
-    ? array.map(item => {
+    ? array.map((item) => {
         // Preserve items that do not have matching ids
         if (!item || item.id !== itemId) {
           return item;

--- a/test/unit/actions/firestore.spec.js
+++ b/test/unit/actions/firestore.spec.js
@@ -838,7 +838,26 @@ describe('firestoreActions', () => {
         instance.test.unsetListeners([{ collection: 'test' }]);
         expect(dispatchSpy).to.have.been.calledWith({
           meta: { collection: 'test' },
-          payload: { name: 'test' },
+          payload: { name: 'test', preserveCache: true },
+          type: actionTypes.UNSET_LISTENER,
+        });
+      });
+
+      it('dispatches UNSET_LISTENER action with preserveCache: false', async () => {
+        const instance = createFirestoreInstance(
+          {
+            _: {
+              pathListenerCounts: { test: 1 },
+              config: { preserveCacheAfterUnset: false },
+            },
+          },
+          { helpersNamespace: 'test' },
+          dispatchSpy,
+        );
+        instance.test.unsetListeners([{ collection: 'test' }]);
+        expect(dispatchSpy).to.have.been.calledWith({
+          meta: { collection: 'test' },
+          payload: { name: 'test', preserveCache: false },
           type: actionTypes.UNSET_LISTENER,
         });
       });

--- a/test/unit/actions/firestore.spec.js
+++ b/test/unit/actions/firestore.spec.js
@@ -51,7 +51,7 @@ describe('firestoreActions', () => {
       onSnapshot: onSnapshotSpy,
     });
     fakeFirebase = {
-      _: { listeners: {}, config: defaultConfig },
+      _: { listeners: {}, pathListenerCounts: {}, config: defaultConfig },
       firestore: () => ({
         collection: collectionClass,
       }),
@@ -831,7 +831,7 @@ describe('firestoreActions', () => {
 
       it('dispatches UNSET_LISTENER action', () => {
         const instance = createFirestoreInstance(
-          {},
+          { _: { pathListenerCounts: { test: 1 } } },
           { helpersNamespace: 'test' },
           dispatchSpy,
         );

--- a/test/unit/reducers/cacheReducer.spec.js
+++ b/test/unit/reducers/cacheReducer.spec.js
@@ -1062,12 +1062,11 @@ describe('cacheReducer', () => {
       };
 
       const pass1 = reducer(initialState, action1);
-      expect(pass1.cache.testStoreAs.docs[0]).to.eql(doc1);
+      expect(pass1.cache.testStoreAs.docs).to.eql([doc1]);
       expect(pass1.cache.database[collection]).to.eql({ [doc1.id]: doc1 });
 
       const pass2 = reducer(pass1, action2);
-
-      expect(pass2.cache.testStoreAs).to.eql(undefined);
+      expect(pass2.cache.testStoreAs.docs).to.eql([doc1]);
       expect(pass2.cache.database[collection]).to.eql({ [doc1.id]: doc1 });
     });
 

--- a/test/unit/reducers/cacheReducer.spec.js
+++ b/test/unit/reducers/cacheReducer.spec.js
@@ -1057,7 +1057,45 @@ describe('cacheReducer', () => {
           storeAs: 'testStoreAs',
           where: ['key1', '==', 'value1'],
         },
-        payload: {}, // actually query string
+        payload: {},
+        type: actionTypes.UNSET_LISTENER,
+      };
+
+      const pass1 = reducer(initialState, action1);
+      expect(pass1.cache.testStoreAs.docs).to.eql([doc1]);
+      expect(pass1.cache.database[collection]).to.eql({ [doc1.id]: doc1 });
+
+      const pass2 = reducer(pass1, action2);
+      expect(pass2.cache.testStoreAs).to.eql(undefined);
+      expect(pass2.cache.database[collection]).to.eql({ [doc1.id]: doc1 });
+    });
+
+    it('unset preserves query and maintains in database cache (preserve mode)', () => {
+      const doc1 = { key1: 'value1', id: 'testDocId1' }; // initial doc
+
+      // Initial seed
+      const action1 = {
+        meta: {
+          collection,
+          storeAs: 'testStoreAs',
+          where: [['key1', '==', 'value1']],
+          orderBy: ['value1'],
+        },
+        payload: {
+          data: { [doc1.id]: doc1 },
+          ordered: [doc1],
+          fromCache: true,
+        },
+        type: actionTypes.LISTENER_RESPONSE,
+      };
+
+      const action2 = {
+        meta: {
+          collection,
+          storeAs: 'testStoreAs',
+          where: ['key1', '==', 'value1'],
+        },
+        payload: { preserveCache: true },
         type: actionTypes.UNSET_LISTENER,
       };
 

--- a/test/unit/reducers/dataReducer.spec.js
+++ b/test/unit/reducers/dataReducer.spec.js
@@ -342,7 +342,7 @@ describe('dataReducer', () => {
           action = {
             meta: { collection },
             payload: { data },
-            preserve: { data: currentState => currentState },
+            preserve: { data: (currentState) => currentState },
             type: actionTypes.LISTENER_ERROR,
           };
           result = dataReducer({ [collection]: {} }, action);

--- a/test/unit/reducers/orderedReducer.spec.js
+++ b/test/unit/reducers/orderedReducer.spec.js
@@ -790,7 +790,7 @@ describe('orderedReducer', () => {
         it('function returns state to save', () => {
           action = {
             type: actionTypes.CLEAR_DATA,
-            preserve: { ordered: currentState => currentState },
+            preserve: { ordered: (currentState) => currentState },
           };
           state = { some: 'value' };
           expect(orderedReducer(state, action)).to.have.property('some');

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -8,7 +8,7 @@ import {
   dataByIdSnapshot,
   getSnapshotByObject,
 } from 'utils/query';
-import { actionTypes } from 'constants';
+import { actionTypes, defaultConfig } from 'constants';
 
 let dispatch = sinon.spy();
 let meta;
@@ -242,13 +242,15 @@ describe('query utils', () => {
 
     it('calls dispatch with unlisten actionType', () => {
       const callbackSpy = sinon.spy();
-      detachListener({ _: { listeners: { test: callbackSpy } } }, dispatch, {
-        collection,
-      });
+      detachListener(
+        { _: { listeners: { test: callbackSpy }, config: defaultConfig } },
+        dispatch,
+        { collection },
+      );
       expect(dispatch).to.be.calledWith({
         type: actionTypes.UNSET_LISTENER,
         meta: { collection },
-        payload: { name: collection },
+        payload: { name: collection, preserveCache: true },
       });
     });
 


### PR DESCRIPTION
### Description

The cached data is removed on `UNSET_LISTENER` which results in a possible blank state when returning to a page (this may lead to other undesirable consequences, in particular scroll will not be preserved). There doesn't seem to be any harm in leaving the data in memory.

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
<!-- * #1 -->
