### PR TITLE
feat: pagination support

### DIFF
--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -287,13 +287,15 @@ const paginateTransducers = (query, isOptimisticWrite = false) => {
 
     docs.forEach((doc) => {
       if (!started && start) {
-        const matched = isPaginateMatched(doc, start, undefined, isAfter);
-        if (matched) started = true;
+        if (isPaginateMatched(doc, start, undefined, isAfter)) {
+          started = true;
+        }
       }
 
       if (started && end) {
-        const matched = isPaginateMatched(doc, end, isBefore, undefined);
-        if (matched) started = false;
+        if (isPaginateMatched(doc, end, isBefore, undefined)) {
+          started = false;
+        }
       }
 
       if (started) {

--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -234,14 +234,21 @@ const filterTransducers = (where) => {
   });
 };
 
+/**
+ * @name paginateTransducers
+ * @param {RRFQuery} query - Firestore wquery
+ * @typedef {Function} xFormFilter - run the same where cause sent to
+ * firestore for all the optimitic overrides
+ * @returns {xFormFilter} - transducer
+ */
 const paginateTransducers = (query) => {
-  const { orderBy, startAt, startAfter, endAt, endBefore } = query;
+  const { orderBy: order, startAt, startAfter, endAt, endBefore } = query;
   const start = startAt || startAfter;
   const end = endAt || endBefore;
   if (start === undefined && end === undefined) return null;
 
-  const isFlat = typeof orderBy[0] === 'string';
-  const orders = isFlat ? [orderBy] : orderBy;
+  const isFlat = typeof order[0] === 'string';
+  const orders = isFlat ? [order] : order;
   const isPaginateMatched = (doc, at, before, after) => {
     let matched = null;
     orders.forEach((field, idx) => {
@@ -250,7 +257,6 @@ const paginateTransducers = (query) => {
       if (value === undefined) return;
 
       // TODO: missing support for document refs
-      const isTimestamp = doc[field]?.nanoseconds >= 0;
       const isMatched = isTimestamp
         ? doc[field]?.seconds === value.seconds &&
           doc[field]?.nanoseconds === value.nanoseconds

--- a/src/utils/mutate.js
+++ b/src/utils/mutate.js
@@ -18,7 +18,7 @@ const promiseAllObject = async (object) =>
   );
 
 const isBatchedWrite = (operations) => Array.isArray(operations);
-const isDocRead = ({ doc } = {}) => doc === 'string';
+const isDocRead = ({ doc } = {}) => typeof doc === 'string';
 const isProviderRead = (read) => isFunction(read);
 const isSingleWrite = ({ collection } = {}) => typeof collection === 'string';
 

--- a/src/utils/mutate.js
+++ b/src/utils/mutate.js
@@ -177,7 +177,7 @@ async function writeInTransaction(firebase, operations) {
         return serialize(snapshot.exsits === false ? null : snapshot);
       }
 
-      // else query (As of 7/2021, Firestore doesn't support client-side queries)
+      // else query (As of 7/2021, Firestore doesn't include queries in client-side transactions)
       const coll = firestoreRef(firebase, read);
       const snapshot = await coll.get();
       if (snapshot.docs.length === 0) return [];

--- a/test/unit/reducers/cacheReducer.spec.js
+++ b/test/unit/reducers/cacheReducer.spec.js
@@ -11,6 +11,38 @@ const initialState = {
   data: { testStoreAs: { obsoleteDocId: {} } },
   ordered: {},
 };
+const testDocId0 = {
+  dateKey: { seconds: 0, nanoseconds: 0 },
+  id: 'testDocId0',
+  other: 'first',
+  path,
+};
+const testDocId1 = {
+  ...testDocId0,
+  dateKey: { seconds: 1, nanoseconds: 1 },
+  other: 'second',
+  id: 'testDocId1',
+};
+const testDocId3 = {
+  ...testDocId0,
+  dateKey: { seconds: 3, nanoseconds: 3 },
+  other: 'third',
+  id: 'testDocId3',
+};
+const testDocId4 = {
+  ...testDocId0,
+  dateKey: { seconds: 4, nanoseconds: 4 },
+  other: 'fourth',
+  id: 'testDocId4',
+};
+
+const primedState = {
+  cache: {
+    database: {
+      [path]: { testDocId0, testDocId1, testDocId3, testDocId4 },
+    },
+  },
+};
 
 describe('cacheReducer', () => {
   describe('optimistic reads', () => {
@@ -76,11 +108,20 @@ describe('cacheReducer', () => {
     });
 
     it('SET_LISTENER returns smaller filtered date', () => {
+      const thresholdDate = { seconds: 0, nanoseconds: 1 };
 
-      const thresholdDate = { seconds: 0, nanoseconds: 1 }
-
-      const doc1 = { dateKey: { seconds: 0, nanoseconds: 0 }, other: 'test', id: 'testDocId1', path };
-      const doc2 = { dateKey: { seconds: 1, nanoseconds: 1 }, other: 'test', id: 'testDocId2', path };
+      const doc1 = {
+        dateKey: { seconds: 0, nanoseconds: 0 },
+        other: 'test',
+        id: 'testDocId1',
+        path,
+      };
+      const doc2 = {
+        dateKey: { seconds: 1, nanoseconds: 1 },
+        other: 'test',
+        id: 'testDocId2',
+        path,
+      };
 
       // Initial seed
       const action1 = {
@@ -114,15 +155,24 @@ describe('cacheReducer', () => {
       const pass2 = reducer(pass1, action2);
 
       expect(pass2.cache.testStoreAs2.docs.length).to.eql(1);
-      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId1')
+      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId1');
     });
 
     it('SET_LISTENER returns greater filtered date', () => {
+      const thresholdDate = { seconds: 0, nanoseconds: 1 };
 
-      const thresholdDate = { seconds: 0, nanoseconds: 1 }
-
-      const doc1 = { dateKey: { seconds: 0, nanoseconds: 0 }, other: 'test', id: 'testDocId1', path };
-      const doc2 = { dateKey: { seconds: 1, nanoseconds: 1 }, other: 'test', id: 'testDocId2', path };
+      const doc1 = {
+        dateKey: { seconds: 0, nanoseconds: 0 },
+        other: 'test',
+        id: 'testDocId1',
+        path,
+      };
+      const doc2 = {
+        dateKey: { seconds: 1, nanoseconds: 1 },
+        other: 'test',
+        id: 'testDocId2',
+        path,
+      };
 
       // Initial seed
       const action1 = {
@@ -156,17 +206,31 @@ describe('cacheReducer', () => {
       const pass2 = reducer(pass1, action2);
 
       expect(pass2.cache.testStoreAs2.docs.length).to.eql(1);
-      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId2')
+      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId2');
     });
 
     it('SET_LISTENER returns smaller or equal filtered date', () => {
+      const thresholdDate = { seconds: 1, nanoseconds: 1 };
 
-      const thresholdDate = { seconds: 1, nanoseconds: 1 }
-  
-      const doc1 = { dateKey: { seconds: 0, nanoseconds: 0 }, other: 'test', id: 'testDocId1', path };
-      const doc2 = { dateKey: { seconds: 1, nanoseconds: 1 }, other: 'test', id: 'testDocId2', path };
-      const doc3 = { dateKey: { seconds: 3, nanoseconds: 3 }, other: 'test', id: 'testDocId3', path };
-  
+      const doc1 = {
+        dateKey: { seconds: 0, nanoseconds: 0 },
+        other: 'test',
+        id: 'testDocId1',
+        path,
+      };
+      const doc2 = {
+        dateKey: { seconds: 1, nanoseconds: 1 },
+        other: 'test',
+        id: 'testDocId2',
+        path,
+      };
+      const doc3 = {
+        dateKey: { seconds: 3, nanoseconds: 3 },
+        other: 'test',
+        id: 'testDocId3',
+        path,
+      };
+
       // Initial seed
       const action1 = {
         meta: {
@@ -182,7 +246,7 @@ describe('cacheReducer', () => {
         },
         type: actionTypes.LISTENER_RESPONSE,
       };
-  
+
       const action2 = {
         meta: {
           collection,
@@ -194,23 +258,37 @@ describe('cacheReducer', () => {
         payload: { name: 'testStoreAs2' },
         type: actionTypes.SET_LISTENER,
       };
-  
+
       const pass1 = reducer(initialState, action1);
       const pass2 = reducer(pass1, action2);
-  
+
       expect(pass2.cache.testStoreAs2.docs.length).to.eql(2);
-      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId1')
-      expect(pass2.cache.testStoreAs2.docs[1].id).to.eql('testDocId2')
+      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId1');
+      expect(pass2.cache.testStoreAs2.docs[1].id).to.eql('testDocId2');
     });
 
     it('SET_LISTENER returns greater or equal filtered date', () => {
+      const thresholdDate = { seconds: 1, nanoseconds: 1 };
 
-      const thresholdDate = { seconds: 1, nanoseconds: 1 }
-  
-      const doc1 = { dateKey: { seconds: 0, nanoseconds: 0 }, other: 'test', id: 'testDocId1', path };
-      const doc2 = { dateKey: { seconds: 1, nanoseconds: 1 }, other: 'test', id: 'testDocId2', path };
-      const doc3 = { dateKey: { seconds: 3, nanoseconds: 3 }, other: 'test', id: 'testDocId3', path };
-  
+      const doc1 = {
+        dateKey: { seconds: 0, nanoseconds: 0 },
+        other: 'test',
+        id: 'testDocId1',
+        path,
+      };
+      const doc2 = {
+        dateKey: { seconds: 1, nanoseconds: 1 },
+        other: 'test',
+        id: 'testDocId2',
+        path,
+      };
+      const doc3 = {
+        dateKey: { seconds: 3, nanoseconds: 3 },
+        other: 'test',
+        id: 'testDocId3',
+        path,
+      };
+
       // Initial seed
       const action1 = {
         meta: {
@@ -226,7 +304,7 @@ describe('cacheReducer', () => {
         },
         type: actionTypes.LISTENER_RESPONSE,
       };
-  
+
       const action2 = {
         meta: {
           collection,
@@ -238,23 +316,37 @@ describe('cacheReducer', () => {
         payload: { name: 'testStoreAs2' },
         type: actionTypes.SET_LISTENER,
       };
-  
+
       const pass1 = reducer(initialState, action1);
       const pass2 = reducer(pass1, action2);
-  
+
       expect(pass2.cache.testStoreAs2.docs.length).to.eql(2);
-      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId2')
-      expect(pass2.cache.testStoreAs2.docs[1].id).to.eql('testDocId3')
+      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId2');
+      expect(pass2.cache.testStoreAs2.docs[1].id).to.eql('testDocId3');
     });
 
     it('SET_LISTENER returns exact filtered date', () => {
+      const thresholdDate = { seconds: 1, nanoseconds: 1 };
 
-      const thresholdDate = { seconds: 1, nanoseconds: 1 }
-  
-      const doc1 = { dateKey: { seconds: 0, nanoseconds: 0 }, other: 'test', id: 'testDocId1', path };
-      const doc2 = { dateKey: { seconds: 1, nanoseconds: 1 }, other: 'test', id: 'testDocId2', path };
-      const doc3 = { dateKey: { seconds: 3, nanoseconds: 3 }, other: 'test', id: 'testDocId3', path };
-  
+      const doc1 = {
+        dateKey: { seconds: 0, nanoseconds: 0 },
+        other: 'test',
+        id: 'testDocId1',
+        path,
+      };
+      const doc2 = {
+        dateKey: { seconds: 1, nanoseconds: 1 },
+        other: 'test',
+        id: 'testDocId2',
+        path,
+      };
+      const doc3 = {
+        dateKey: { seconds: 3, nanoseconds: 3 },
+        other: 'test',
+        id: 'testDocId3',
+        path,
+      };
+
       // Initial seed
       const action1 = {
         meta: {
@@ -270,7 +362,7 @@ describe('cacheReducer', () => {
         },
         type: actionTypes.LISTENER_RESPONSE,
       };
-  
+
       const action2 = {
         meta: {
           collection,
@@ -282,58 +374,117 @@ describe('cacheReducer', () => {
         payload: { name: 'testStoreAs2' },
         type: actionTypes.SET_LISTENER,
       };
-  
+
       const pass1 = reducer(initialState, action1);
       const pass2 = reducer(pass1, action2);
-  
+
       expect(pass2.cache.testStoreAs2.docs.length).to.eql(1);
-      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId2')
+      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId2');
     });
 
-    it('SET_LISTENER returns different filtered date', () => {
-
-      const thresholdDate = { seconds: 1, nanoseconds: 1 }
-  
-      const doc1 = { dateKey: { seconds: 0, nanoseconds: 0 }, other: 'test', id: 'testDocId1', path };
-      const doc2 = { dateKey: { seconds: 1, nanoseconds: 1 }, other: 'test', id: 'testDocId2', path };
-      const doc3 = { dateKey: { seconds: 3, nanoseconds: 3 }, other: 'test', id: 'testDocId3', path };
-  
-      // Initial seed
-      const action1 = {
+    it('SET_LISTENER pagination with startAt', () => {
+      const stateDesc = {
         meta: {
           collection,
           storeAs: 'testStoreAs',
-          orderBy: ['dateKey'],
-          fields: ['id', 'other'],
+          orderBy: ['dateKey', 'desc'],
+          startAt: { seconds: 2, nanoseconds: 2 },
+          limit: 2,
         },
-        payload: {
-          data: { [doc1.id]: doc1, [doc2.id]: doc2, [doc3.id]: doc3 },
-          ordered: [doc1, doc2],
-          fromCache: true,
-        },
-        type: actionTypes.LISTENER_RESPONSE,
-      };
-  
-      const action2 = {
-        meta: {
-          collection,
-          storeAs: 'testStoreAs2',
-          where: [['dateKey', '!=', thresholdDate]],
-          orderBy: ['dateKey'],
-          fields: ['id', 'other'],
-        },
-        payload: { name: 'testStoreAs2' },
+        payload: { name: 'testStoreAs' },
         type: actionTypes.SET_LISTENER,
       };
-  
-      const pass1 = reducer(initialState, action1);
-      const pass2 = reducer(pass1, action2);
-  
-      expect(pass2.cache.testStoreAs2.docs.length).to.eql(2);
-      expect(pass2.cache.testStoreAs2.docs[0].id).to.eql('testDocId1')
-      expect(pass2.cache.testStoreAs2.docs[1].id).to.eql('testDocId3')
+      const stateAsc = JSON.parse(JSON.stringify(stateDesc));
+      stateAsc.meta.orderBy = ['dateKey'];
+
+      const passA = reducer(primedState, stateDesc);
+      expect(passA.cache.testStoreAs.docs[0].id).to.eql('testDocId1');
+      expect(passA.cache.testStoreAs.docs[1].id).to.eql('testDocId0');
+      expect(passA.cache.testStoreAs.docs[2]).to.eql(undefined);
+
+      const passB = reducer(primedState, stateAsc);
+      expect(passB.cache.testStoreAs.docs[0].id).to.eql('testDocId3');
+      expect(passB.cache.testStoreAs.docs[1].id).to.eql('testDocId4');
+      expect(passB.cache.testStoreAs.docs[2]).to.eql(undefined);
     });
 
+    it('SET_LISTENER pagination with startAfter', () => {
+      const stateDesc = {
+        meta: {
+          collection,
+          storeAs: 'testStoreAs',
+          orderBy: ['dateKey', 'desc'],
+          startAfter: { seconds: 2, nanoseconds: 2 },
+          limit: 2,
+        },
+        payload: { name: 'testStoreAs' },
+        type: actionTypes.SET_LISTENER,
+      };
+      const stateAsc = JSON.parse(JSON.stringify(stateDesc));
+      stateAsc.meta.orderBy = ['dateKey', 'asc'];
+
+      const passA = reducer(primedState, stateDesc);
+      expect(passA.cache.testStoreAs.docs[0].id).to.eql('testDocId1');
+      expect(passA.cache.testStoreAs.docs[1].id).to.eql('testDocId0');
+      expect(passA.cache.testStoreAs.docs[2]).to.eql(undefined);
+
+      const passB = reducer(primedState, stateAsc);
+      expect(passB.cache.testStoreAs.docs[0].id).to.eql('testDocId3');
+      expect(passB.cache.testStoreAs.docs[1].id).to.eql('testDocId4');
+      expect(passB.cache.testStoreAs.docs[2]).to.eql(undefined);
+    });
+
+    it('SET_LISTENER pagination with endAt', () => {
+      const stateDesc = {
+        meta: {
+          collection,
+          storeAs: 'testStoreAs',
+          orderBy: ['dateKey', 'desc'],
+          endAt: { seconds: 2, nanoseconds: 2 },
+          limit: 2,
+        },
+        payload: { name: 'testStoreAs' },
+        type: actionTypes.SET_LISTENER,
+      };
+      const stateAsc = JSON.parse(JSON.stringify(stateDesc));
+      stateAsc.meta.orderBy = ['dateKey', 'asc'];
+
+      const passA = reducer(primedState, stateDesc);
+      expect(passA.cache.testStoreAs.docs[0].id).to.eql('testDocId4');
+      expect(passA.cache.testStoreAs.docs[1].id).to.eql('testDocId3');
+      expect(passA.cache.testStoreAs.docs[2]).to.eql(undefined);
+
+      const passB = reducer(primedState, stateAsc);
+      expect(passB.cache.testStoreAs.docs[0].id).to.eql('testDocId0');
+      expect(passB.cache.testStoreAs.docs[1].id).to.eql('testDocId1');
+      expect(passB.cache.testStoreAs.docs[2]).to.eql(undefined);
+    });
+
+    it('SET_LISTENER pagination with endBefore', () => {
+      const stateDesc = {
+        meta: {
+          collection,
+          storeAs: 'testStoreAs',
+          orderBy: ['dateKey', 'desc'],
+          endBefore: { seconds: 2, nanoseconds: 2 },
+          limit: 2,
+        },
+        payload: { name: 'testStoreAs' },
+        type: actionTypes.SET_LISTENER,
+      };
+      const stateAsc = JSON.parse(JSON.stringify(stateDesc));
+      stateAsc.meta.orderBy = ['dateKey'];
+
+      const passA = reducer(primedState, stateDesc);
+      expect(passA.cache.testStoreAs.docs[0].id).to.eql('testDocId4');
+      expect(passA.cache.testStoreAs.docs[1].id).to.eql('testDocId3');
+      expect(passA.cache.testStoreAs.docs[2]).to.eql(undefined);
+
+      const passB = reducer(primedState, stateAsc);
+      expect(passB.cache.testStoreAs.docs[0].id).to.eql('testDocId0');
+      expect(passB.cache.testStoreAs.docs[1].id).to.eql('testDocId1');
+      expect(passB.cache.testStoreAs.docs[2]).to.eql(undefined);
+    });
   });
 
   describe('query fields', () => {

--- a/test/unit/utils/mutate.spec.js
+++ b/test/unit/utils/mutate.spec.js
@@ -104,7 +104,7 @@ describe('firestore.mutate()', () => {
     expect(commit.calledTwice);
   });
 
-  it('writes in transaction', async () => {
+  it('writes transaction w/ provider, query & doc', async () => {
     const firestoreGet = sinon.spy(() =>
       Promise.resolve({
         docs: [
@@ -150,6 +150,7 @@ describe('firestore.mutate()', () => {
       { firestore },
       {
         reads: {
+          org: () => `tara`,
           team: {
             collection: 'orgs/tara-ai/teams',
             doc: 'team-id-123',
@@ -163,9 +164,9 @@ describe('firestore.mutate()', () => {
           },
         },
         writes: [
-          ({ unfinishedTasks, team }) =>
+          ({ org, unfinishedTasks, team }) =>
             unfinishedTasks.map((task) => ({
-              collection: 'orgs/tara-ai/tasks',
+              collection: `orgs/${org}/tasks`,
               doc: task.id,
               data: {
                 'nested.field': 'new-value',
@@ -196,7 +197,7 @@ describe('firestore.mutate()', () => {
     );
   });
 
-  it('writes transaction with single write', async () => {
+  it('writes transaction w/ single write', async () => {
     const firestoreGet = sinon.spy(() =>
       Promise.resolve({
         docs: [


### PR DESCRIPTION
### Description

1. Support pagination that we need to fix the sprint columns from loading/showing sprint is the wrong order. 

2. Added mutate read providers. This lets us force writes to be static but include local state so that writes are idempotent when running in the reducer, Firestore client & Firestore server.
```ts
const myStaticWrite = (({someLocalState, someDoc}) => ({
  ...someDoc,
  withLocalState: someLocalState?.a === 1 ? 'isOne' : false,
});

function sendMutate( ){
  const myVar = {a: 1};
  mutate({
     reads: {
       someLocalState: () => myVar, 
       someDoc: {collection:'cities', doc: 'sf'}
     },
     writes: [myStaticWrite]
   })
}
```

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [-] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues
- added timestamp support to `orderBy`
- added support in mutate for read providers
- added support for page cursors (startAt, startAfter, endAt, endBefore) in reducer for optimistic read + writes



https://user-images.githubusercontent.com/140163/125853782-183c3f31-312e-4868-81bf-a73bccb85047.mov

