### PR TITLE
fix: pagination and optimistic write creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-firestore",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Redux bindings for Firestore.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/actions/firestore.js
+++ b/src/actions/firestore.js
@@ -416,9 +416,12 @@ export function runTransaction(firebase, dispatch, transactionPromise) {
  * @returns {Promise} Resolves with results of update call
  */
 export function mutate(firebase, dispatch, writes) {
+  const timestamp = `${+new Date()}`;
+
   return wrapInDispatch(dispatch, {
     ref: firebase,
     method: 'mutate',
+    meta: { timestamp },
     args: [writes],
     types: [
       {
@@ -428,6 +431,7 @@ export function mutate(firebase, dispatch, writes) {
       actionTypes.MUTATE_SUCCESS,
       {
         type: actionTypes.MUTATE_FAILURE,
+        meta: { timestamp },
         payload: { data: writes },
       },
     ],

--- a/src/createFirestoreInstance.js
+++ b/src/createFirestoreInstance.js
@@ -102,7 +102,6 @@ export default function createFirestoreInstance(firebase, configs, dispatch) {
  *        dispatch({ type: 'SOME_ACTION' })
  *      })
  * };
- *
  */
 export function getFirestore() {
   /* istanbul ignore next: Firestore instance always exists during tests */

--- a/src/reducers/cacheReducer.js
+++ b/src/reducers/cacheReducer.js
@@ -279,8 +279,9 @@ const xfPaginate = (query, getDoc) => {
   const end = endAt || endBefore;
   const isAfter = startAfter !== undefined;
   const isBefore = endBefore !== undefined;
+  const needsPagination = start || end || false;
 
-  if (!order || !isOptimisticRead || !!start || !!end) return identity;
+  if (!needsPagination || !order || !isOptimisticRead) return identity;
 
   const isFlat = typeof order[0] === 'string';
   const orders = isFlat ? [order] : order;

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -2,12 +2,8 @@ import { actionTypes } from '../constants';
 import { getSlashStrPath, combineReducers } from '../utils/reducers';
 import { getQueryName } from '../utils/query';
 
-const {
-  SET_LISTENER,
-  UNSET_LISTENER,
-  LISTENER_ERROR,
-  LISTENER_RESPONSE,
-} = actionTypes;
+const { SET_LISTENER, UNSET_LISTENER, LISTENER_ERROR, LISTENER_RESPONSE } =
+  actionTypes;
 
 /**
  * Reducer for requesting state.Changed by `START`, `NO_VALUE`, and `SET` actions.

--- a/test/unit/reducers/cacheReducer.spec.js
+++ b/test/unit/reducers/cacheReducer.spec.js
@@ -265,8 +265,8 @@ describe('cacheReducer', () => {
       const passA = reducer(primedState, stateDesc);
       expect(passA.cache.testStoreAs).to.eql({
         ordered: [
-          ['testCollection', 'testDocId4'],
-          ['testCollection', 'testDocId3'],
+          ['testCollection', 'testDocId1'],
+          ['testCollection', 'testDocId0'],
         ],
         collection: 'testCollection',
         storeAs: 'testStoreAs',
@@ -279,8 +279,8 @@ describe('cacheReducer', () => {
       const passB = reducer(primedState, stateAsc);
       expect(passB.cache.testStoreAs).to.eql({
         ordered: [
-          ['testCollection', 'testDocId0'],
-          ['testCollection', 'testDocId1'],
+          ['testCollection', 'testDocId3'],
+          ['testCollection', 'testDocId4'],
         ],
         collection: 'testCollection',
         storeAs: 'testStoreAs',
@@ -306,8 +306,8 @@ describe('cacheReducer', () => {
       const passA = reducer(primedState, stateDesc);
       expect(passA.cache.testStoreAs).to.eql({
         ordered: [
-          ['testCollection', 'testDocId4'],
-          ['testCollection', 'testDocId3'],
+          ['testCollection', 'testDocId1'],
+          ['testCollection', 'testDocId0'],
         ],
         collection: 'testCollection',
         storeAs: 'testStoreAs',
@@ -320,8 +320,8 @@ describe('cacheReducer', () => {
       const passB = reducer(primedState, stateAsc);
       expect(passB.cache.testStoreAs).to.eql({
         ordered: [
-          ['testCollection', 'testDocId0'],
-          ['testCollection', 'testDocId1'],
+          ['testCollection', 'testDocId3'],
+          ['testCollection', 'testDocId4'],
         ],
         collection: 'testCollection',
         storeAs: 'testStoreAs',
@@ -344,8 +344,8 @@ describe('cacheReducer', () => {
       const passA = reducer(primedState, stateDesc);
       expect(passA.cache.testStoreAs).to.eql({
         ordered: [
-          ['testCollection', 'testDocId1'],
-          ['testCollection', 'testDocId0'],
+          ['testCollection', 'testDocId4'],
+          ['testCollection', 'testDocId3'],
         ],
         collection: 'testCollection',
         storeAs: 'testStoreAs',
@@ -358,8 +358,8 @@ describe('cacheReducer', () => {
       const passB = reducer(primedState, stateAsc);
       expect(passB.cache.testStoreAs).to.eql({
         ordered: [
-          ['testCollection', 'testDocId3'],
-          ['testCollection', 'testDocId4'],
+          ['testCollection', 'testDocId0'],
+          ['testCollection', 'testDocId1'],
         ],
         collection: 'testCollection',
         storeAs: 'testStoreAs',
@@ -385,8 +385,8 @@ describe('cacheReducer', () => {
       const passA = reducer(primedState, stateDesc);
       expect(passA.cache.testStoreAs).to.eql({
         ordered: [
-          ['testCollection', 'testDocId1'],
-          ['testCollection', 'testDocId0'],
+          ['testCollection', 'testDocId4'],
+          ['testCollection', 'testDocId3'],
         ],
         collection: 'testCollection',
         storeAs: 'testStoreAs',
@@ -399,8 +399,8 @@ describe('cacheReducer', () => {
       const passB = reducer(primedState, stateAsc);
       expect(passB.cache.testStoreAs).to.eql({
         ordered: [
-          ['testCollection', 'testDocId3'],
-          ['testCollection', 'testDocId4'],
+          ['testCollection', 'testDocId0'],
+          ['testCollection', 'testDocId1'],
         ],
         collection: 'testCollection',
         storeAs: 'testStoreAs',

--- a/test/unit/reducers/cacheReducer.spec.js
+++ b/test/unit/reducers/cacheReducer.spec.js
@@ -529,6 +529,19 @@ describe('cacheReducer', () => {
       expect(pass1.cache.testStoreAs.ordered[0][1]).to.eql(doc1.id);
       expect(pass2.cache.testStoreAs.ordered[0][1]).to.eql(doc2.id);
       expect(pass3.cache.testStoreAs.ordered[0][1]).to.eql(doc1.id);
+
+      // overrides must be cleared
+      expect(pass2.cache.databaseOverrides).to.eql({
+        testCollection: {
+          testDocId1: {
+            id: 'testDocId1',
+            key1: 'value1',
+            key2: 'other',
+            path: 'testCollection',
+          },
+        },
+      });
+      expect(pass3.cache.databaseOverrides).to.eql({});
     });
 
     it('overrides synchronously moves to new query', () => {

--- a/test/unit/utils/query.spec.js
+++ b/test/unit/utils/query.spec.js
@@ -612,9 +612,8 @@ describe('query utils', () => {
 
       describe('startAfter', () => {
         it('calls startAfter if valid', () => {
-          const { theFirebase, theSpy, theMeta } = fakeFirebaseWith(
-            'startAfter',
-          );
+          const { theFirebase, theSpy, theMeta } =
+            fakeFirebaseWith('startAfter');
           result = firestoreRef(theFirebase, theMeta);
           expect(result).to.be.an('object');
           expect(theSpy).to.be.calledWith(theMeta.subcollections[0].startAfter);


### PR DESCRIPTION
### Description

- Fix optimistic writes to make sure object instead id + path (lines 539 + 847)
- Fix pagination so that results are the same as Firestore. (line 284)
- added timestamp to meta for better mutation handling

### Check List
If not relevant to pull request, check off as complete

- [x] All tests passing
- [x] Docs updated with any changes or examples if applicable
- [x] Added tests to ensure new feature(s) work properly

### Relevant Issues

| Before | 
| --- | 
| Set_listener (with optimistic read, results are different) <img width="1072" alt="Screen Shot 2021-08-09 at 4 51 20 PM" src="https://user-images.githubusercontent.com/140163/128789817-438a5c25-d2c0-4179-a83f-cecf77a348a6.png">
Listener_response (from firestore, results are different) <img width="1072" alt="Screen Shot 2021-08-09 at 4 51 32 PM" src="https://user-images.githubusercontent.com/140163/128789771-ed74bb0f-1595-479d-abdb-eea9a0690ed7.png">  |

| After |
| --- |
| Set_listener (with optimistic read results are the same) <img width="965" alt="Screen Shot 2021-08-09 at 6 16 55 PM" src="https://user-images.githubusercontent.com/140163/128789914-71e55417-64dd-4675-97c0-b01125f07bb1.png"> Listener_response (from firestore, results are the same) <img width="965" alt="Screen Shot 2021-08-09 at 6 13 36 PM" src="https://user-images.githubusercontent.com/140163/128789864-69a51e81-eaf5-46ee-97c1-aa7a3a6c3ffd.png">
 

